### PR TITLE
[DO NOT MERGE] Config vars

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,7 @@ gem 'bootsnap', require: false
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri mingw x64_mingw]
-  gem "dotenv-rails"
+  gem 'dotenv-rails'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -50,9 +50,12 @@ gem 'bootsnap', require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+# gem 'env'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri mingw x64_mingw]
+  gem "dotenv-rails"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,10 @@ GEM
     debug (1.8.0)
       irb (>= 1.5.0)
       reline (>= 0.3.1)
+    dotenv (2.8.1)
+    dotenv-rails (2.8.1)
+      dotenv (= 2.8.1)
+      railties (>= 3.2)
     erubi (1.12.0)
     globalid (1.1.0)
       activesupport (>= 5.0)
@@ -215,6 +219,7 @@ DEPENDENCIES
   bootsnap
   capybara
   debug
+  dotenv-rails
   importmap-rails
   jbuilder
   puma (~> 5.0)

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class HomeController < ApplicationController
+  helper_method :ui_version
   # before_action :set_css_file, only: [
   #   :version_one,
   #   :version_one_page_one,
@@ -55,4 +56,54 @@ class HomeController < ApplicationController
   #   end
   # end
 
+  def root
+    Rails.logger.info "UI_VERSION: #{ui_version}"
+    puts "UI_VERSION: #{ENV['UI_VERSION']}"
+    puts "Template path: home/#{ui_version}/#{ui_version}"
+    puts "Layout path: layouts/#{ui_version}/#{ui_version}"
+    render template: "home/#{ui_version}/#{ui_version}", layout: "layouts/#{ui_version}/#{ui_version}"
+  end
+
+  def page_one
+    render template: "home/#{ui_version}/page_one", layout: "layouts/#{ui_version}/#{ui_version}"
+  end
+
+  def page_two
+    render template: "home/#{ui_version}/page_two", layout: "layouts/#{ui_version}/#{ui_version}"
+  end
+
+  def page_three
+    render template: "home/#{ui_version}/page_three", layout: "layouts/#{ui_version}/#{ui_version}"
+  end
+
+  private
+
+  def ui_version
+    # params[:ui_version] || ENV['UI_VERSION'] || 'version-one'
+    ENV['UI_VERSION'] || 'version-one'
+  end
+
+  def version_one_page_one_path
+    home_page_one_path(ui_version: 'version-one')
+  end
+
+  def version_one_page_two_path
+    home_page_two_path(ui_version: 'version-one')
+  end
+
+  def version_one_page_three_path
+    home_page_three_path(ui_version: 'version-one')
+  end
+
+  def version_two_page_one_path
+    home_page_one_path(ui_version: 'version-two')
+  end
+
+  def version_two_page_two_path
+    home_page_two_path(ui_version: 'version-two')
+  end
+
+  def version_two_page_three_path
+    home_page_three_path(ui_version: 'version-two')
+  end
 end

--- a/app/controllers/version_one_controller.rb
+++ b/app/controllers/version_one_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class VersionOneController < ApplicationController
   before_action :set_css_file
 

--- a/app/controllers/version_two_controller.rb
+++ b/app/controllers/version_two_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class VersionTwoController < ApplicationController
   before_action :set_css_file
 

--- a/app/helpers/version_one_helper.rb
+++ b/app/helpers/version_one_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 module VersionOneHelper
 end

--- a/app/helpers/version_two_helper.rb
+++ b/app/helpers/version_two_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 module VersionTwoHelper
 end

--- a/app/views/home/root.html.erb
+++ b/app/views/home/root.html.erb
@@ -1,0 +1,1 @@
+<p>COMMON TEMPLATE</p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-    
+
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,6 +9,7 @@ require 'rails/all'
 Bundler.require(*Rails.groups)
 
 module ManageDifferentUIs
+
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,23 +1,57 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  get 'home/homepage'
+  # get 'home/homepage'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")
   # root "articles#index"
 
-  scope '/version-one', as: 'version_one' do
-    get '', to: 'version_one#version_one', as: 'index'
-    get 'page-one', to: 'version_one#version_one_page_one', as: 'page_one'
-    get 'page-two', to: 'version_one#version_one_page_two', as: 'page_two'
-    get 'page-three', to: 'version_one#version_one_page_three', as: 'page_three'
+  # scope '/version-one', as: 'version_one' do
+  #   get '', to: 'version_one#version_one', as: 'index'
+  #   get 'page-one', to: 'version_one#version_one_page_one', as: 'page_one'
+  #   get 'page-two', to: 'version_one#version_one_page_two', as: 'page_two'
+  #   get 'page-three', to: 'version_one#version_one_page_three', as: 'page_three'
+  # end
+
+  # scope '/version-two', as: 'version_two' do
+  #   get '', to: 'version_two#version_two', as: 'index'
+  #   get 'page-one', to: 'version_two#version_two_page_one', as: 'page_one'
+  #   get 'page-two', to: 'version_two#version_two_page_two', as: 'page_two'
+  #   get 'page-three', to: 'version_two#version_two_page_three', as: 'page_three'
+  # end
+
+  # root to: 'home#root'
+
+  # get "/:ui_version(/:action)", controller: 'home', action: 'page_one', constraints: { ui_version: /version-one|version-two/ }, defaults: { ui_version: ENV['UI_VERSION'] || 'version-one' } do
+  #   get 'page-one', action: 'page_one'
+  #   get 'page-two', action: 'page_two'
+  #   get 'page-three', action: 'page_three'
+  # end
+
+  # root to: 'home#root'
+
+  # get '/:ui_version/page_one', to: 'home#page_one'
+  # get '/:ui_version/page_two', to: 'home#page_two'
+  # get '/:ui_version/page_three', to: 'home#page_three'
+
+  # root to: 'home#root'
+
+  # get '/version-one/page_one', to: 'version_one#page_one'
+  # get '/version-one/page_two', to: 'version_one#page_two'
+  # get '/version-one/page_three', to: 'version_one#page_three'
+
+  # get '/version-two/page_one', to: 'version_two#page_one'
+  # get '/version-two/page_two', to: 'version_two#page_two'
+  # get '/version-two/page_three', to: 'version_two#page_three'
+
+  UI_VERSION_CONSTRAINT = /(version-one|version-two)/
+
+  scope lambda { |request| { ui_version: request.env['UI_VERSION'] || 'version-one' } }, constraints: { ui_version: UI_VERSION_CONSTRAINT } do
+    root to: 'home#root'
+    get '/page_one', to: 'home#page_one'
+    get '/page_two', to: 'home#page_two'
+    get '/page_three', to: 'home#page_three'
   end
 
-  scope '/version-two', as: 'version_two' do
-    get '', to: 'version_two#version_two', as: 'index'
-    get 'page-one', to: 'version_two#version_two_page_one', as: 'page_one'
-    get 'page-two', to: 'version_two#version_two_page_two', as: 'page_two'
-    get 'page-three', to: 'version_two#version_two_page_three', as: 'page_three'
-  end
 end

--- a/test/controllers/version_one_controller_test.rb
+++ b/test/controllers/version_one_controller_test.rb
@@ -1,4 +1,6 @@
-require "test_helper"
+# frozen_string_literal: true
+
+require 'test_helper'
 
 class VersionOneControllerTest < ActionDispatch::IntegrationTest
   # test "the truth" do

--- a/test/controllers/version_two_controller_test.rb
+++ b/test/controllers/version_two_controller_test.rb
@@ -1,4 +1,6 @@
-require "test_helper"
+# frozen_string_literal: true
+
+require 'test_helper'
 
 class VersionTwoControllerTest < ActionDispatch::IntegrationTest
   # test "the truth" do


### PR DESCRIPTION
**WIP**

**HOME CONTROLLER**
In the Home Controller, I created a private method to `def ui_version` to determine the UI version that should be displayed. It gets the UI version that is set in the ENV file, if neither is set, it defaults to the version-one.

There are methods to generate paths for different pages under the UI version. 

**ROUTES**
I used a lambda scope method to dynamically define a constraint based on the UI version in the env var. It helps to apply the constraint to ensure that only URLS containing version one or version two match the ui_version.

**CURRENT ISSUES**
- Unable to dynamically load version-one or version-two with the above configuration
- I may be duplicating some part of the code or it has gotten a bit messy and something is contradicting something. 
- It reports missing template without the lambda scope method, because it is trying to find both version one and version two and I am not sure why it is doing that. 